### PR TITLE
Ability to view available time slots for practitioner

### DIFF
--- a/docs/Assignment.md
+++ b/docs/Assignment.md
@@ -30,7 +30,7 @@ Design and implement the core components of an on-line scheduling application fo
   - [x] a 90 minutes initial consultation, 
   - [x] standard 60 minute appointments and,
   - [x] 30 minute check-ins.
-- [ ] Appointments do not overlap. There can only be one booked appointment at any time.
+- [x] Appointments do not overlap. There can only be one booked appointment at any time.
 - [x] Appointments start on:
   - [x] the hour or,
   - [x] half-hour.
@@ -41,10 +41,10 @@ Design and implement the core components of an on-line scheduling application fo
 
 ### Patient
 
-- [ ] Provide the patient with a list of available appointment times. Inputs are the appointment type and a date, either today or in the future. The 2 hour booking deadline applies for today’s appointments.
-- [ ] Allow the patient to book an appointment.
+- [x] Provide the patient with a list of available appointment times. Inputs are the appointment type and a date, either today or in the future. The 2 hour booking deadline applies for today’s appointments.
+- [x] Allow the patient to book an appointment.
 
 ### Practitioner
 
-- [ ] List scheduled appointments for the current day.
+- [x] List scheduled appointments for the current day.
 

--- a/docs/Design and Implementation Thoughts.md
+++ b/docs/Design and Implementation Thoughts.md
@@ -11,6 +11,8 @@
 - Even without a Validator, Illegal Argument Exceptions should be more specific (other than just the message content) when there is an exception creating a domain class. UPDATE: I decided to return a list of errors for both Appointments and Bookings when they are validated as this seems quite important for an initial UI.
 - ~~There is duplication of validation logic in the constructors with and without ids but it'll start for now until proper validators are in place.~~ I removed constructors with ids as they'll only be needed when repositories are created.
 - I'm going to put my business logic encapsulating the business rules in the domain classes. We can refactor that out when we implement a UI and data persistence. We can also debase Onion, Clean, Vertical Slice and other architecture pattens at that time.
+- I should add a lot more tests (especially edge cases), for viewing available time slots and adding a booking.
+- **We REALLY need to synchronize the adding of a booking!**
 
 ## Domain Modelling
 
@@ -20,7 +22,7 @@ It seems, in an absolute minimal MVP, we should likely only have patient and pra
 Yet my wife gave up her appointment with a practitioner so that I could have urgently needed care at a clinic IRL (a clinic that uses Jane App) so I really want to include them in both class definitions. I realize that this could be construed as building for "future requirements", though :smile:
 
 **Should any class have clinic?**  
-Hmm, for a first release, there is only one clinic so technically we don't need to associate it with practitioners (and, by association, to bookings and appointments).
+Hmm, for a first release, there is only one clinic so technically we don't need to associate it with practitioners (and, by association, to bookings and appointments). Actually, right at the end, I realized we should have a clinic associated with a practitioner so we know the clinics hours when displaying available start times for appointments.
 
 I'll treat it as a nice to have (and call this building for the *near* future). Hmm, should a practitioner work at more than one clinic? I know some RMTs do IRL... More reason to defer it for now, as it's likely a domain question.
 

--- a/src/main/java/ca/kittle/clinic/domain/Clinic.java
+++ b/src/main/java/ca/kittle/clinic/domain/Clinic.java
@@ -3,6 +3,7 @@ package ca.kittle.clinic.domain;
 import lombok.Getter;
 import util.CustomValidator;
 
+import java.time.Duration;
 import java.time.LocalTime;
 
 @Getter
@@ -11,6 +12,7 @@ public class Clinic {
     // TODO hardcoding opening and closing times for MVP, this should be externalized
     private static final LocalTime OPENING_TIME = LocalTime.of(9, 0);
     private static final LocalTime CLOSING_TIME = LocalTime.of(17, 0);
+    public static final Duration BOOKING_START_TIME_INTERVAL = Duration.ofMinutes(30);
 
     private static final String NAME_NULL_ERROR = "Clinic name cannot be null or blank";
     private static final String PHONE_NULL_ERROR = "Clinic phone number cannot be null or blank";

--- a/src/main/java/ca/kittle/clinic/domain/Practitioner.java
+++ b/src/main/java/ca/kittle/clinic/domain/Practitioner.java
@@ -75,6 +75,20 @@ public class Practitioner {
                 .toList();
     }
 
+    public List<LocalTime> availabileTimes(LocalDate forDate, Appointment.AppointmentType appointmentType) {
+        List<LocalTime> times = new ArrayList<>();
+        List<Booking> bookings = listBookings(forDate);
+        // FIXME Need to use actual clinic hours here, not hardcoded values
+        for (int hour = 9; hour < 17; hour++) {
+            for (int minute = 0; minute < 60; minute += (int) Clinic.BOOKING_START_TIME_INTERVAL.toMinutes()) {
+                LocalTime startTime = LocalTime.of(hour, minute);
+                LocalTime endTime = startTime.plusMinutes(appointmentType.getDuration().toMinutes());
+                if (!Booking.doAppointmentTimesOverlapOtherBookings(startTime, endTime, bookings))
+                    times.add(startTime);
+            }
+        }
+        return times;
+    }
 
     /**
      * Cancels an existing booking for this practitioner.

--- a/src/test/java/ca/kittle/clinic/domain/BookingBusinessRuleTest.java
+++ b/src/test/java/ca/kittle/clinic/domain/BookingBusinessRuleTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BookingBusinessRuleTest {
+class BookingBusinessRuleTest {
 
     private static final List<Patient> patients = TestPatients.getAllPatients();
 
@@ -57,7 +57,7 @@ public class BookingBusinessRuleTest {
                         clinicHours,
                         type,
                         bookingDate,
-                        startTime.minusMinutes(30),
+                        startTime.minusMinutes(Clinic.BOOKING_START_TIME_INTERVAL.toMinutes()),
                         patient,
                         practitioner);
         assertTrue(result.isLeft() && result.getLeft().isPresent());
@@ -80,6 +80,7 @@ public class BookingBusinessRuleTest {
         LocalTime startTime = clinicHours.getOpeningTime();
 
         Either<List<BookingValidationError>, Booking> result;
+        // FIXME this is working with the assumption bookings are ONLY on the hour and half hour, should use Clinic.BOOKING_START_TIME_INTERVAL here.
         for (int i = 1; i < 30; i++) {
             result =
                     Booking.createBooking(


### PR DESCRIPTION
Made it easier to check a pair of start and end times against all existing bookings to determine any overlap. Added booking start time interval (hardcoded to 30 minutes) so I can start removing the hardcoded value of 30 from code. Eventually configurable per clinic